### PR TITLE
Make TraverseEmpty[Chain] serializable

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -618,7 +618,7 @@ private[data] sealed abstract class ChainInstances extends ChainInstances1 {
     }
 
   implicit val catsDataTraverseEmptyForChain: TraverseEmpty[Chain] = new TraverseEmpty[Chain] {
-    def traverse: Traverse[Chain] = catsDataInstancesForChain
+    def traverse: Traverse[Chain] = Chain.catsDataInstancesForChain
 
     override def filter[A](fa: Chain[A])(f: A => Boolean): Chain[A] = fa.filter(f)
 


### PR DESCRIPTION
I think that the issue here is that it was referencing an instance-level
`catsDataInstancesForChain` from an abstract class. By changing it to
reference `Chain.catsDataInstancesForChain`, it is a reference to a
static member (and therefore doesn't actually need to be serialized).

Take my explanation with a grain of salt -- like everyone else on the
planet, I don't actually understand Java serialization. But at the end
of the day it works :)